### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,14 @@
+{% extends template.self %}
+
+{% block javascript %}
+    {{ super() }}
+    <script>
+    var _hmt = _hmt || [];
+    (function() {
+        var hm = document.createElement('script');
+        hm.src = '//hm.baidu.com/hm.js?{{ config.pluginsConfig.baidu.token }}';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(hm, s);
+    })();
+    </script>
+{% endblock %}

--- a/index.js
+++ b/index.js
@@ -3,17 +3,6 @@ module.exports = {
         assets: "./book",
         js: [
             "plugin.js"
-        ],
-        html: {
-            "body:end": function() {
-                return "<script>var _hmt = _hmt || [];"
-                    + "(function() {"
-                    + "var hm = document.createElement('script');"
-                    + "hm.src = '//hm.baidu.com/hm.js?" + this.options.pluginsConfig.baidu.token + "';"
-                    + "var s = document.getElementsByTagName('script')[0];"
-                    + "s.parentNode.insertBefore(hm, s);"
-                    + "})();</script>";
-            }
-        }
+        ]
     }
 };


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version and includes the script using the templating system. Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

In your new version's `package.json`, don't forget to specify:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
